### PR TITLE
Repoint CODEOWNERS to silicom-ltd maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,8 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @albertofloyd @VenkatKotakonda @kashah1
+# btsil=Bill Terrell, jjdalynh=Jeff Daly, wwang22=Wen Wang (all have write access).
+*       @btsil @jjdalynh @wwang22
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
@@ -11,5 +12,5 @@
 
 
 # You can also use email addresses if you prefer.
-doc/*	@albertofloyd @kashah1
+doc/*	@btsil @jjdalynh @wwang22
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,16 +1,4 @@
-# Lines starting with '#' are comments.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in the repo.
+# Code owners for this repo. A lone '*' matches every file recursively,
+# so these owners are required reviewers on all PRs into this branch.
 # btsil=Bill Terrell, jjdalynh=Jeff Daly, wwang22=Wen Wang (all have write access).
 *       @btsil @jjdalynh @wwang22
-
-# Order is important. The last matching pattern has the most precedence.
-# So if a pull request only touches javascript files, only these owners
-# will be requested to review.
-#*.js    @octocat @github/js
-
-
-# You can also use email addresses if you prefer.
-doc/*	@btsil @jjdalynh @wwang22
-


### PR DESCRIPTION
## Why
`Require review from Code Owners` is now enabled on `mec172x_adl_n_cadiz`, but the existing CODEOWNERS listed `@albertofloyd @VenkatKotakonda @kashah1` — upstream-fork leftovers with **read-only** access. Read-only users are not valid code owners, so the rule was effectively toothless (no valid owner to require).

## Change
Repoint ownership to maintainers with write access:
- `@btsil` (Bill Terrell)
- `@jjdalynh` (Jeff Daly)
- `@wwang22` (Wen Wang)

Applies to `*` and `doc/*`.

## Note
Since GitHub reads CODEOWNERS from the PR base branch, this must land on `mec172x_adl_n_cadiz` to take effect for PRs into that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)