### PR TITLE
Cadiz: add MGMT green and red GPIO LEDs

### DIFF
--- a/out_of_tree_boards/boards/arm/mec172x_adl_n_cadiz/mec172x_adl_n_cadiz.dts
+++ b/out_of_tree_boards/boards/arm/mec172x_adl_n_cadiz/mec172x_adl_n_cadiz.dts
@@ -34,6 +34,8 @@
 		gpioled2 = &gpioled2;
 		gpioled3 = &gpioled3;
 		gpioled4 = &gpioled4;
+		gpioled5 = &gpioled5;
+		gpioled6 = &gpioled6;
 		eeprom0 = &eeprom;
 	};
 
@@ -88,10 +90,26 @@
 		};
 	};
 
-	/* Blue: mgmt, bottom-right (GPIO053) — active-low; no full RGB PWM available */
+	/* Red: mgmt, bottom-right (GPIO222) — active-low; no full RGB PWM available */
 	gpioled4: gpioled4 {
 		compatible = "gpio-leds";
 		gpio_led4: led-4 {
+			gpios = <&gpio_200_236 18 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/* Green: mgmt, bottom-right (GPIO054) — active-low; no full RGB PWM available */
+	gpioled5: gpioled5 {
+		compatible = "gpio-leds";
+		gpio_led5: led-5 {
+			gpios = <&gpio_040_076 12 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	/* Blue: mgmt, bottom-right (GPIO053) — active-low; no full RGB PWM available */
+	gpioled6: gpioled6 {
+		compatible = "gpio-leds";
+		gpio_led6: led-6 {
 			gpios = <&gpio_040_076 11 GPIO_ACTIVE_LOW>;
 		};
 	};


### PR DESCRIPTION
## Summary

- Add `gpioled4` (Red, GPIO222), `gpioled5` (Green, GPIO054), and `gpioled6` (Blue, GPIO053) gpio-led nodes for the MGMT bottom-right indicator
- All three are active-low with no full RGB PWM available

## Test plan

- [x] Built firmware and validated on hardware
- [x] Green and red LEDs confirmed functional