### PR TITLE
Switch sequence ext blair ddr5

### DIFF
--- a/app/smchost/smchost.c
+++ b/app/smchost/smchost.c
@@ -472,6 +472,25 @@ void send_to_host(uint8_t *pdata, uint8_t Len)
 	host_res_idx = 0;
 }
 
+/**
+ * @brief Receive data from the host.
+ *
+ * @param  ptr pointer to the data.
+ * return      length of data bytes.
+ */
+uint8_t recv_from_host(uint8_t *pdata)
+{
+    uint8_t i;
+    uint8_t len = host_req_len;
+
+    for (i = 0; i < len; i++) {
+        // host_req[0] has a command byte
+        pdata[i] = host_req[i+1];
+        LOG_DBG("Rcvd data: %02X", pdata[i]);
+    }
+    return len;
+}
+
 static void service_system_acpi_cmds(void)
 {
 	if (!g_acpi_state_flags.acpi_mode) {
@@ -635,6 +654,9 @@ static uint8_t smchost_req_length(uint8_t command)
 	case SMCHOST_WRITE_ACPI_SPACE:
 		return 2;
 
+    case SMCHOST_GET_SYS_IDS:
+        return 7;
+
 	default:
 		return 0;
 	}
@@ -656,6 +678,7 @@ static void smchost_cmd_handler(uint8_t command)
 	case SMCHOST_READ_PLAT_SIGNATURE:
 	case SMCHOST_HID_BTN_SCI_CONTROL:
 	case SMCHOST_HID_RST_BTN_SCI_CONTROL:
+	case SMCHOST_GET_SYS_IDS:
 		smchost_cmd_info_handler(command);
 		break;
 	case SMCHOST_PLN_CONFIG:

--- a/app/smchost/smchost.h
+++ b/app/smchost/smchost.h
@@ -81,6 +81,14 @@ void smchost_thread(void *p1, void *p2, void *p3);
  */
 void send_to_host(uint8_t *pdata, uint8_t len);
 
+/**
+ * @brief Receive data from SMC host.
+ *
+ * @param pdata pointer to buffer holding the data.
+ * return       length of bytes to be received.
+ */
+uint8_t recv_from_host(uint8_t *pdata);
+
 #ifdef CONFIG_SMCHOST_EVENT_DRIVEN_TASK
 /**
  * @brief Indicate smchost task there is an event that requires to be processed.

--- a/app/smchost/smchost_commands.h
+++ b/app/smchost/smchost_commands.h
@@ -82,6 +82,7 @@
 #define SMCHOST_DNX_TRIGGER		0xF6
 #define SMCHOST_DNX_SET_STRAP		0xF7
 #endif
+#define SMCHOST_GET_SYS_IDS         0x4D
 
 #endif /* __SMCHOST_COMMANDS_H__ */
 

--- a/app/smchost/smchost_info.c
+++ b/app/smchost/smchost_info.c
@@ -170,7 +170,7 @@ static void get_sys_ids(void)
     len = recv_from_host(ids);
     if (len > 0)
     {
-        set_sys_ids((const uint8_t *)&ids[0], len);
+        set_sys_ids(ids, len);
     }
     else
     {

--- a/app/smchost/smchost_info.c
+++ b/app/smchost/smchost_info.c
@@ -162,6 +162,22 @@ static void read_revision(void)
 	send_to_host((uint8_t *)&version, 2);
 }
 
+static void get_sys_ids(void)
+{
+    uint8_t len = 0;
+    uint8_t ids[SMCHOST_MAX_BUF_SIZE] = {0};
+
+    len = recv_from_host(ids);
+    if (len > 0)
+    {
+        set_sys_ids((const uint8_t *)&ids[0], len);
+    }
+    else
+    {
+        LOG_DBG("%s, failed length(%u)", __func__, len);
+    }
+}
+
 static void read_platform_signature(void)
 {
 	uint8_t value[8];
@@ -199,6 +215,10 @@ void smchost_cmd_info_handler(uint8_t command)
 		LOG_INF("RST_BTN_SCI_CONTROL received");
 		rstbtn_sci_cntrl();
 		break;
+	case SMCHOST_GET_SYS_IDS:
+        LOG_DBG("%s, SMCHOST_GET_SYS_IDS", __func__);
+        get_sys_ids();
+        break;
 	default:
 		LOG_WRN("%s: command 0x%X without handler", __func__, command);
 		break;

--- a/boards/silicom/adl_n_cp_board.c
+++ b/boards/silicom/adl_n_cp_board.c
@@ -20,8 +20,47 @@
 LOG_MODULE_REGISTER(board, CONFIG_BOARD_LOG_LEVEL);
 
 static uint16_t plat_data = 0x2400;
+static struct sys_ids g_sys_ids;
 
 uint16_t get_platform_id(void)
 {
 	return plat_data;
+}
+
+uint8_t get_bom_id (void)
+{
+    return g_sys_ids.bom_id;
+}
+
+uint8_t get_board_id (void)
+{
+    return g_sys_ids.board_id;
+}
+
+struct sbl_version *get_sbl_version(void)
+{
+    /*
+      major_version;
+      minor_version;
+      build_number_high;
+      build_number_low;
+      flags;
+        //flags: [3:0]reserved, [4]image_arch,
+        //       [5]bld_debug,  [6]fsp_debug,
+        //       [7]dirty
+    */
+
+    return &g_sys_ids.sbl;
+}
+
+void set_sys_ids(const uint8_t *pdata, uint8_t len)
+{
+    uint8_t i = 0;
+    uint8_t *ptr = (uint8_t *)&g_sys_ids;
+
+    while (i != len && i < 10)
+    {
+        ptr[i] = pdata[i];
+        i++;
+    }
 }

--- a/boards/silicom/adl_n_cp_board.c
+++ b/boards/silicom/adl_n_cp_board.c
@@ -55,12 +55,5 @@ struct sbl_version *get_sbl_version(void)
 
 void set_sys_ids(const uint8_t *pdata, uint8_t len)
 {
-    uint8_t i = 0;
-    uint8_t *ptr = (uint8_t *)&g_sys_ids;
-
-    while (i != len && i < 10)
-    {
-        ptr[i] = pdata[i];
-        i++;
-    }
+    memcpy(&g_sys_ids, pdata, len);
 }

--- a/boards/silicom/adl_n_cp_mec172x.h
+++ b/boards/silicom/adl_n_cp_mec172x.h
@@ -147,4 +147,42 @@ extern uint8_t platformskutype;
  */
 #define USB_PD_VERSION 0x0200
 
+/* MAESTRO DDR4 and DDR5 bom ids, board id */
+#define MAESTRO_DDR4_BOM_ID             0x04
+#define MAESTRO_DDR5_BOM_ID             0x05
+#define MAESTRO_BOARD_ID                0x15
+#define MAESTRO_VTT_SODIMM_ADC_CHNL     14
+
+// struct sbl version for LOM
+struct sbl_version {
+    uint8_t major_version;
+    uint8_t minor_version;
+    uint8_t build_number_high;
+    uint8_t build_number_low;
+    uint8_t flags;
+            //flags:    [3:0]reserved, [4]image_arch,
+            //          [5]bld_debug,  [6]fsp_debug,
+            //          [7]dirty
+};
+
+/**
+    struct sys_ids holds all the members of struct sbl_version
+    e.g major, minor, bld_number_high and bld_number_low, flags,
+    and additionally board_id and bom_id
+**/
+struct sys_ids {
+    struct sbl_version sbl;
+    uint8_t board_id;
+    uint8_t bom_id;
+};
+
+/**
+    functions to set and get sbl version,
+    board_id and bom_id
+**/
+void set_sys_ids (const uint8_t *pdata, uint8_t len);
+uint8_t get_bom_id (void);
+uint8_t get_board_id (void);
+struct sbl_version *get_sbl_version(void);
+
 #endif /* __AZBEACH_MEC172X_H__ */

--- a/drivers/sensors.c
+++ b/drivers/sensors.c
@@ -33,6 +33,8 @@ static const struct device *ntc_thermal_sensors[] = {
 	DT_INST_FOREACH_STATUS_OKAY(THERMAL_SENSOR)
 };
 
+static void maestro_ddr5_vtt_sodimm(struct sensor_value *volts);
+
 int thermal_sensors_init()
 {
 	int i;
@@ -80,11 +82,11 @@ void thermal_sensors_update(void)
 
 		err = sensor_sample_fetch_chan(ntc_thermal_sensors[i], SENSOR_CHAN_AMBIENT_TEMP);
 		if (err) {
-			LOG_WRN("ADC Sensor reading failed %d, %s\n", i, ntc_thermal_sensors[i]->name);
+			LOG_WRN("ADC (%02u) thermistor reading failed %s\n", adc_dt->channel_cfg.channel_id, ntc_thermal_sensors[i]->name);
 			continue;
 		}
 		sensor_channel_get(ntc_thermal_sensors[i], SENSOR_CHAN_AMBIENT_TEMP, &temp);
-		LOG_INF("Sensor %d thermistor read: %d.%03dC", i, temp.val1, temp.val2);
+		LOG_INF("ADC (%02u) thermistor read: %d.%03dC", adc_dt->channel_cfg.channel_id, temp.val1, temp.val2);
 
 		old_multiplier = sdata->multiplier;
 		multiplier = 0;
@@ -155,7 +157,6 @@ int voltage_monitor_init(void)
 	return 0;
 }
 
-
 void voltage_monitor_update(void)
 {
 	int i, num_sensors = ARRAY_SIZE(voltage_sensors);
@@ -182,11 +183,25 @@ void voltage_monitor_update(void)
 
 		err = sensor_sample_fetch_chan(voltage_sensors[i], SENSOR_CHAN_VOLTAGE);
 		if (err) {
-			LOG_WRN("ADC voltage reading failed %d, %s\n", i, voltage_sensors[i]->name);
+			LOG_WRN("ADC (%02u) voltage reading failed, %s\n", voltage->port.channel_id, voltage_sensors[i]->name);
 			continue;
 		}
 		sensor_channel_get(voltage_sensors[i], SENSOR_CHAN_VOLTAGE, &volts);
-		LOG_INF("ADC %d voltage read: %d.%03d V", i, volts.val1, volts.val2);
+
+        /**
+            The call to maestro_ddr5_vtt_sodimm() function will correct
+            VTT_SODIMM voltage reading for DDR5 board due to addition of
+            the voltage divider.
+        **/
+        if (voltage->port.channel_id == MAESTRO_VTT_SODIMM_ADC_CHNL)
+        {
+            if (get_bom_id() == MAESTRO_DDR5_BOM_ID)
+            {
+                maestro_ddr5_vtt_sodimm (&volts);
+            }
+        }
+
+		LOG_INF("ADC (%02u) voltage read: %d.%06d V", voltage->port.channel_id, volts.val1, volts.val2);
 
 		//sdata->mon_in = (volts.val1 << 16) | (volts.val2 / 16);
 		sdata->mon_in = (volts.val1 * 1000) + (volts.val2 / 1000);
@@ -244,11 +259,11 @@ void current_sense_update(void)
 
 		err = sensor_sample_fetch_chan(current_sensors[i], SENSOR_CHAN_CURRENT);
 		if (err) {
-			LOG_WRN("ADC current reading failed %d, %s\n", i, current_sensors[i]->name);
+			LOG_WRN("ADC (%02u) current reading failed, %s\n", current->port.channel_id, current_sensors[i]->name);
 			continue;
 		}
 		sensor_channel_get(current_sensors[i], SENSOR_CHAN_CURRENT, &amps);
-		LOG_INF("ADC %d current read: %d.%d mA", i, amps.val1, amps.val2);
+		LOG_INF("ADC (%02u) current read: %d.%03d mA", current->port.channel_id, amps.val1, amps.val2);
 
 		old_multiplier = sdata->multiplier;
 		multiplier = 0;
@@ -318,6 +333,26 @@ void sensors_update()
 	voltage_monitor_update();
 	thermal_sensors_update();
 	current_sense_update();
-
 }
+
+/**
+    This function converts the volt to milivolt,
+    then apply the voltage divider formula to get
+    the input voltage and converts back to volt.
+**/
+static void maestro_ddr5_vtt_sodimm (struct sensor_value *volts)
+{
+    // R1 resistor -> 1K
+    // R2 resistor -> 1K
+    //uint16_t output_ohms = 10000;
+    //uint16_t full_ohms = 10000+10000;
+
+    uint32_t v_mv = (volts->val1 * 1000) + (volts->val2 / 1000);
+    //v_mv = (v_mv * full_ohms) / output_ohms;
+    v_mv = v_mv * 2;
+
+    volts->val1 = v_mv / 1000;
+    volts->val2 = (v_mv * 1000) % 1000000;
+}
+
 #undef DT_DRV_COMPAT


### PR DESCRIPTION
I have introduced the system ids  which have (sbl version, board id and bom id), total 7 bytes which will be received by the command 0x4D.

Although the sbl version is only required on ibiza for LOM but Maestro also needs the bomId to work for VTT_SODIMM voltage reading on ADC channel 14. I decided to package this and make it generic in case for future use.

As soon as the bomId arrives, the VTT_SODIMM voltage changes to correct reading

[00:00:02.144,561] <inf> thrmsens: ADC (12) voltage read: 1.086000 V
**[00:00:02.144,592] <inf> thrmsens: ADC (14) voltage read: 2.584000 V**
[00:00:02.322,479] <inf> smchost: EC Command: 2D
[00:00:02.326,904] <inf> smchost: EC Command: 0D
[00:00:02.352,203] <inf> smchost: EC Command: 2D
[00:00:02.356,689] <inf> smchost: EC Command: 90
[00:00:02.403,015] <inf> smchost: EC Command: 4D
[00:00:02.403,015] <inf> smchost: Rcvd data: 00
[00:00:02.403,015] <inf> smchost: Rcvd data: 00
[00:00:02.403,045] <inf> smchost: Rcvd data: 00
[00:00:02.403,045] <inf> smchost: Rcvd data: 10
[00:00:02.403,045] <inf> smchost: Rcvd data: A0
[00:00:02.403,045] <inf> smchost: Rcvd data: 15
[00:00:02.403,045] <inf> smchost: Rcvd data: 05
[00:00:03.145,721] <inf> thrmsens: ESPI EC1_SRAM: 0x00118fc0

 [00:00:03.146,728] <inf> thrmsens: ADC (00) voltage read: 12.219000 V
[00:00:03.146,759] <inf> thrmsens: ADC (01) voltage read: 5.162000 V
[00:00:03.146,820] <inf> thrmsens: ADC (02) voltage read: 3.296000 V
[00:00:03.146,850] <inf> thrmsens: ADC (03) voltage read: 1.801000 V
[00:00:03.146,881] <inf> thrmsens: ADC (09) voltage read: 1.795000 V
[00:00:03.146,911] <inf> thrmsens: ADC (11) voltage read: 1.791000 V
[00:00:03.146,942] <inf> thrmsens: ADC (12) voltage read: 1.089000 V
**[00:00:03.147,003] <inf> thrmsens: ADC (14) voltage read: 5.168000 V**
[00:00:04.148,315] <inf> thrmsens: ESPI EC1_SRAM: 0x00118fc0