### PR TITLE
Mec172x adl n lom blair sbl ver

### DIFF
--- a/app/smchost/smchost.c
+++ b/app/smchost/smchost.c
@@ -462,6 +462,25 @@ void send_to_host(uint8_t *pdata, uint8_t Len)
 	host_res_idx = 0;
 }
 
+/**
+ * @brief Receive data from the host.
+ *
+ * @param  ptr pointer to the data.
+ * return      length of data bytes.
+ */
+uint8_t recv_from_host(uint8_t *pdata)
+{
+    uint8_t i;
+    uint8_t len = host_req_len;
+
+    for (i = 0; i < len; i++) {
+        // host_req[0] has a command byte
+        pdata[i] = host_req[i+1];
+        LOG_DBG("Rcvd data: %02X", pdata[i]);
+    }
+    return len;
+}
+
 static void service_system_acpi_cmds(void)
 {
 	if (!g_acpi_state_flags.acpi_mode) {
@@ -625,6 +644,9 @@ static uint8_t smchost_req_length(uint8_t command)
 	case SMCHOST_WRITE_ACPI_SPACE:
 		return 2;
 
+    case SMCHOST_GET_SYS_IDS:
+        return 7;
+
 	default:
 		return 0;
 	}
@@ -646,6 +668,7 @@ static void smchost_cmd_handler(uint8_t command)
 	case SMCHOST_READ_PLAT_SIGNATURE:
 	case SMCHOST_HID_BTN_SCI_CONTROL:
 	case SMCHOST_HID_RST_BTN_SCI_CONTROL:
+    case SMCHOST_GET_SYS_IDS:
 		smchost_cmd_info_handler(command);
 		break;
 	case SMCHOST_PLN_CONFIG:

--- a/app/smchost/smchost.h
+++ b/app/smchost/smchost.h
@@ -81,6 +81,14 @@ void smchost_thread(void *p1, void *p2, void *p3);
  */
 void send_to_host(uint8_t *pdata, uint8_t len);
 
+/**
+ * @brief Receive data from SMC host.
+ *
+ * @param pdata pointer to buffer holding the data.
+ * return       length of bytes to be received.
+ */
+uint8_t recv_from_host(uint8_t *pdata);
+
 #ifdef CONFIG_SMCHOST_EVENT_DRIVEN_TASK
 /**
  * @brief Indicate smchost task there is an event that requires to be processed.

--- a/app/smchost/smchost_commands.h
+++ b/app/smchost/smchost_commands.h
@@ -81,6 +81,7 @@
 #define SMCHOST_DNX_TRIGGER		0xF6
 #define SMCHOST_DNX_SET_STRAP		0xF7
 #endif
+#define SMCHOST_GET_SYS_IDS         0x4D
 
 #endif /* __SMCHOST_COMMANDS_H__ */
 

--- a/app/smchost/smchost_info.c
+++ b/app/smchost/smchost_info.c
@@ -162,6 +162,22 @@ static void read_revision(void)
 	send_to_host((uint8_t *)&version, 2);
 }
 
+static void get_sys_ids(void)
+{
+    uint8_t len = 0;
+    uint8_t ids[SMCHOST_MAX_BUF_SIZE] = {0};
+
+    len = recv_from_host(ids);
+    if (len > 0)
+    {
+        set_sys_ids(ids, len);
+    }
+    else
+    {
+        LOG_DBG("%s, failed length(%u)", __func__, len);
+    }
+}
+
 static void read_platform_signature(void)
 {
 	uint8_t value[8];
@@ -199,6 +215,10 @@ void smchost_cmd_info_handler(uint8_t command)
 		LOG_INF("RST_BTN_SCI_CONTROL received");
 		rstbtn_sci_cntrl();
 		break;
+    case SMCHOST_GET_SYS_IDS:
+        LOG_DBG("%s, SMCHOST_GET_SYS_IDS", __func__);
+        get_sys_ids();
+        break;
 	default:
 		LOG_WRN("%s: command 0x%X without handler", __func__, command);
 		break;

--- a/boards/silicom/adl_n_board.c
+++ b/boards/silicom/adl_n_board.c
@@ -20,8 +20,47 @@
 LOG_MODULE_REGISTER(board, CONFIG_BOARD_LOG_LEVEL);
 
 static uint16_t plat_data = 0x2300;
+static struct sys_ids g_sys_ids;
 
 uint16_t get_platform_id(void)
 {
 	return plat_data;
+}
+
+uint8_t get_bom_id (void)
+{
+    return g_sys_ids.bom_id;
+}
+
+uint8_t get_board_id (void)
+{
+    return g_sys_ids.board_id;
+}
+
+struct sbl_version *get_sbl_version(void)
+{
+    /*
+      major_version;
+      minor_version;
+      build_number_high;
+      build_number_low;
+      flags;
+        //flags: [3:0]reserved, [4]image_arch,
+        //       [5]bld_debug,  [6]fsp_debug,
+        //       [7]dirty
+    */
+
+    return &g_sys_ids.sbl;
+}
+
+void set_sys_ids(const uint8_t *pdata, uint8_t len)
+{
+    uint8_t i = 0;
+    uint8_t *ptr = (uint8_t *)&g_sys_ids;
+
+    while (i != len && i < 10)
+    {
+        ptr[i] = pdata[i];
+        i++;
+    }
 }

--- a/boards/silicom/adl_n_board.c
+++ b/boards/silicom/adl_n_board.c
@@ -55,12 +55,5 @@ struct sbl_version *get_sbl_version(void)
 
 void set_sys_ids(const uint8_t *pdata, uint8_t len)
 {
-    uint8_t i = 0;
-    uint8_t *ptr = (uint8_t *)&g_sys_ids;
-
-    while (i != len && i < 10)
-    {
-        ptr[i] = pdata[i];
-        i++;
-    }
+    memcpy(&g_sys_ids, pdata, len);
 }

--- a/boards/silicom/adl_n_mec172x.h
+++ b/boards/silicom/adl_n_mec172x.h
@@ -141,4 +141,36 @@ extern uint8_t platformskutype;
  */
 #define USB_PD_VERSION 0x0200
 
+// struct sbl version for LOM
+struct sbl_version {
+    uint8_t major_version;
+    uint8_t minor_version;
+    uint8_t build_number_high;
+    uint8_t build_number_low;
+    uint8_t flags;
+            //flags:  [3:0]reserved, [4]image_arch,
+            //        [5]bld_debug,  [6]fsp_debug,
+            //        [7]dirty
+};
+
+/**
+    struct sys_ids holds all the members of struct sbl_version
+    e.g major, minor, bld_number_high and bld_number_low, flags,
+    and additionally board_id and bom_id
+**/
+struct sys_ids {
+    struct sbl_version sbl;
+    uint8_t board_id;
+    uint8_t bom_id;
+};
+
+/**
+    functions to set and get sbl version,
+    board_id and bom_id
+**/
+void set_sys_ids (const uint8_t *pdata, uint8_t len);
+uint8_t get_bom_id (void);
+uint8_t get_board_id (void);
+struct sbl_version *get_sbl_version(void);
+
 #endif /* __AZBEACH_MEC172X_H__ */


### PR DESCRIPTION
I have introduced the system ids which have (sbl version, board id and bom id), total 7 bytes which will be received by the command 0x4D for ibiza/LOM

From SBL:
Receiving EC Data: 09
BomId: 0x04 (SKU: G04)
Sending EC Command: 4D
SendEcDataTimeout sent 4D 
Sending EC Data: 07
Sending EC Data: 08
Sending EC Data: 00
Sending EC Data: 54
Sending EC Data: A0
Sending EC Data: 14
Sending EC Data: 04
Not Found Saved MRC Data!

On EC:
[00:00:02.405,670] <inf> smchost: EC Command: 4D
[00:00:02.405,670] <inf> smchost: Rcvd data: 07
[00:00:02.405,670] <inf> smchost: Rcvd data: 08
[00:00:02.405,670] <inf> smchost: Rcvd data: 00
[00:00:02.405,700] <inf> smchost: Rcvd data: 54
[00:00:02.405,700] <inf> smchost: Rcvd data: A0
[00:00:02.405,700] <inf> smchost: Rcvd data: 14
[00:00:02.405,700] <inf> smchost: Rcvd data: 04

Note:

The SBL version can be retrieved from the following function
e.g

```
struct sbl_version *sbl = get_sbl_version();

// struct sbl version for LOM
struct sbl_version {
    uint8_t major_version;
    uint8_t minor_version;
    uint8_t build_number_high;
    uint8_t build_number_low;
    uint8_t flags;
            //flags:  [3:0]reserved, [4]image_arch,
            //            [5]bld_debug,  [6]fsp_debug,
            //            [7]dirty
};
```

