### PR TITLE
smchost: add GET_LOM_IP host command (IPv4/IPv6 + netmask)

### DIFF
--- a/app/smchost/smchost.c
+++ b/app/smchost/smchost.c
@@ -669,6 +669,7 @@ static void smchost_cmd_handler(uint8_t command)
 	case SMCHOST_HID_BTN_SCI_CONTROL:
 	case SMCHOST_HID_RST_BTN_SCI_CONTROL:
     case SMCHOST_GET_SYS_IDS:
+    case SMCHOST_GET_LOM_IP:
 		smchost_cmd_info_handler(command);
 		break;
 	case SMCHOST_PLN_CONFIG:

--- a/app/smchost/smchost.h
+++ b/app/smchost/smchost.h
@@ -43,8 +43,11 @@
 #define LEGACY_PECI_MODE 0
 #define PECI_OVER_ESPI_MODE 1
 
-/* EC identifier */
-#define SMCHOST_MAX_BUF_SIZE		10
+/* EC identifier.
+ * Must be large enough for the biggest host response; the GET_LOM_IP
+ * reply is up to LOM_IP_RESP_MAX (18) bytes for an IPv6 address.
+ */
+#define SMCHOST_MAX_BUF_SIZE		20
 
 /* Virtual Dock Status */
 #define VIRTUAL_DOCK_CONNECTED 0

--- a/app/smchost/smchost_commands.h
+++ b/app/smchost/smchost_commands.h
@@ -82,6 +82,7 @@
 #define SMCHOST_DNX_SET_STRAP		0xF7
 #endif
 #define SMCHOST_GET_SYS_IDS         0x4D
+#define SMCHOST_GET_LOM_IP          0x4E
 
 #endif /* __SMCHOST_COMMANDS_H__ */
 

--- a/app/smchost/smchost_info.c
+++ b/app/smchost/smchost_info.c
@@ -178,6 +178,14 @@ static void get_sys_ids(void)
     }
 }
 
+static void get_lom_ip(void)
+{
+    uint8_t ip[LOM_IP_ADDR_LEN];
+
+    get_lom_ip_addr(ip);
+    send_to_host(ip, sizeof(ip));
+}
+
 static void read_platform_signature(void)
 {
 	uint8_t value[8];
@@ -218,6 +226,10 @@ void smchost_cmd_info_handler(uint8_t command)
     case SMCHOST_GET_SYS_IDS:
         LOG_DBG("%s, SMCHOST_GET_SYS_IDS", __func__);
         get_sys_ids();
+        break;
+    case SMCHOST_GET_LOM_IP:
+        LOG_DBG("%s, SMCHOST_GET_LOM_IP", __func__);
+        get_lom_ip();
         break;
 	default:
 		LOG_WRN("%s: command 0x%X without handler", __func__, command);

--- a/app/smchost/smchost_info.c
+++ b/app/smchost/smchost_info.c
@@ -180,10 +180,10 @@ static void get_sys_ids(void)
 
 static void get_lom_ip(void)
 {
-    uint8_t ip[LOM_IP_ADDR_LEN];
+    uint8_t resp[LOM_IP_RESP_MAX];
+    uint8_t len = get_lom_ip_resp(resp);
 
-    get_lom_ip_addr(ip);
-    send_to_host(ip, sizeof(ip));
+    send_to_host(resp, len);
 }
 
 static void read_platform_signature(void)

--- a/boards/silicom/adl_n_board.c
+++ b/boards/silicom/adl_n_board.c
@@ -22,8 +22,14 @@ LOG_MODULE_REGISTER(board, CONFIG_BOARD_LOG_LEVEL);
 static uint16_t plat_data = 0x2300;
 static struct sys_ids g_sys_ids;
 
-/* LOM IPv4 address (network order). All-0xFF = not yet reported by the LOM. */
-static uint8_t g_lom_ip[LOM_IP_ADDR_LEN] = { 0xFF, 0xFF, 0xFF, 0xFF };
+/* LOM IP address (network order). family == LOM_IP_FAMILY_NONE means the
+ * LOM has not reported an address yet.
+ */
+static struct {
+	uint8_t family;                   /* LOM_IP_FAMILY_V4 / _V6 / _NONE */
+	uint8_t prefix;                   /* CIDR netmask bits */
+	uint8_t addr[LOM_IPV6_ADDR_LEN];  /* octets, network order */
+} g_lom_ip = { .family = LOM_IP_FAMILY_NONE };
 K_MUTEX_DEFINE(lom_ip_mutex);
 
 uint16_t get_platform_id(void)
@@ -63,26 +69,75 @@ void set_sys_ids(const uint8_t *pdata, uint8_t len)
 }
 
 /*
- * Store the LOM IPv4 address reported over the (separately handled) LOM
+ * Store the LOM IP address reported over the (separately handled) LOM
  * management link. Writer runs in the lom_mgmt thread context while the
  * reader runs in the smchost thread, so guard the copy with a mutex.
+ *
+ * family selects IPv4 (4 octets) or IPv6 (16 octets); len must match the
+ * family. addr holds the octets in network order (addr[0] = most
+ * significant). prefix is the subnet mask as a CIDR bit count.
  */
-void set_lom_ip(const uint8_t *addr, uint8_t len)
+void set_lom_ip(uint8_t family, uint8_t prefix, const uint8_t *addr, uint8_t len)
 {
-    if (len < LOM_IP_ADDR_LEN) {
-        LOG_WRN("%s: short LOM IP length %u", __func__, len);
+    uint8_t expected;
+
+    switch (family) {
+    case LOM_IP_FAMILY_V4:
+        expected = LOM_IPV4_ADDR_LEN;
+        break;
+    case LOM_IP_FAMILY_V6:
+        expected = LOM_IPV6_ADDR_LEN;
+        break;
+    default:
+        LOG_WRN("%s: bad LOM IP family 0x%02X", __func__, family);
+        return;
+    }
+
+    if (len != expected) {
+        LOG_WRN("%s: LOM IP len %u != %u for family 0x%02X",
+                __func__, len, expected, family);
         return;
     }
 
     k_mutex_lock(&lom_ip_mutex, K_FOREVER);
-    memcpy(g_lom_ip, addr, LOM_IP_ADDR_LEN);
+    g_lom_ip.family = family;
+    g_lom_ip.prefix = prefix;
+    memset(g_lom_ip.addr, 0, sizeof(g_lom_ip.addr));
+    memcpy(g_lom_ip.addr, addr, len);
     k_mutex_unlock(&lom_ip_mutex);
 }
 
-/* Copy the 4 IPv4 octets to out[]; all-0xFF if the LOM has not reported one. */
-void get_lom_ip_addr(uint8_t *out)
+/*
+ * Build the host response into out[] (must be >= LOM_IP_RESP_MAX bytes):
+ * [family][prefix][address octets]. Returns the number of bytes written.
+ * When no address has been reported, only family + prefix are written
+ * (family == LOM_IP_FAMILY_NONE).
+ */
+uint8_t get_lom_ip_resp(uint8_t *out)
 {
+    uint8_t len = 0;
+    uint8_t addr_len;
+
     k_mutex_lock(&lom_ip_mutex, K_FOREVER);
-    memcpy(out, g_lom_ip, LOM_IP_ADDR_LEN);
+
+    switch (g_lom_ip.family) {
+    case LOM_IP_FAMILY_V4:
+        addr_len = LOM_IPV4_ADDR_LEN;
+        break;
+    case LOM_IP_FAMILY_V6:
+        addr_len = LOM_IPV6_ADDR_LEN;
+        break;
+    default:
+        addr_len = 0;
+        break;
+    }
+
+    out[len++] = g_lom_ip.family;
+    out[len++] = g_lom_ip.prefix;
+    memcpy(&out[len], g_lom_ip.addr, addr_len);
+    len += addr_len;
+
     k_mutex_unlock(&lom_ip_mutex);
+
+    return len;
 }

--- a/boards/silicom/adl_n_board.c
+++ b/boards/silicom/adl_n_board.c
@@ -22,6 +22,9 @@ LOG_MODULE_REGISTER(board, CONFIG_BOARD_LOG_LEVEL);
 static uint16_t plat_data = 0x2300;
 static struct sys_ids g_sys_ids;
 
+/* LOM IPv4 address (network order). All-0xFF = not yet reported by the LOM. */
+static uint8_t g_lom_ip[LOM_IP_ADDR_LEN] = { 0xFF, 0xFF, 0xFF, 0xFF };
+
 uint16_t get_platform_id(void)
 {
 	return plat_data;
@@ -56,4 +59,33 @@ struct sbl_version *get_sbl_version(void)
 void set_sys_ids(const uint8_t *pdata, uint8_t len)
 {
     memcpy(&g_sys_ids, pdata, len);
+}
+
+/*
+ * Store the LOM IPv4 address reported over the (separately handled) LOM
+ * management link. Writer runs in the lom_mgmt thread context while the
+ * reader runs in the smchost thread, so guard the copy against tearing.
+ */
+void set_lom_ip(const uint8_t *addr, uint8_t len)
+{
+    unsigned int key;
+
+    if (len < LOM_IP_ADDR_LEN) {
+        LOG_WRN("%s: short LOM IP length %u", __func__, len);
+        return;
+    }
+
+    key = irq_lock();
+    memcpy(g_lom_ip, addr, LOM_IP_ADDR_LEN);
+    irq_unlock(key);
+}
+
+/* Copy the 4 IPv4 octets to out[]; all-0xFF if the LOM has not reported one. */
+void get_lom_ip_addr(uint8_t *out)
+{
+    unsigned int key;
+
+    key = irq_lock();
+    memcpy(out, g_lom_ip, LOM_IP_ADDR_LEN);
+    irq_unlock(key);
 }

--- a/boards/silicom/adl_n_board.c
+++ b/boards/silicom/adl_n_board.c
@@ -24,6 +24,7 @@ static struct sys_ids g_sys_ids;
 
 /* LOM IPv4 address (network order). All-0xFF = not yet reported by the LOM. */
 static uint8_t g_lom_ip[LOM_IP_ADDR_LEN] = { 0xFF, 0xFF, 0xFF, 0xFF };
+K_MUTEX_DEFINE(lom_ip_mutex);
 
 uint16_t get_platform_id(void)
 {
@@ -64,28 +65,24 @@ void set_sys_ids(const uint8_t *pdata, uint8_t len)
 /*
  * Store the LOM IPv4 address reported over the (separately handled) LOM
  * management link. Writer runs in the lom_mgmt thread context while the
- * reader runs in the smchost thread, so guard the copy against tearing.
+ * reader runs in the smchost thread, so guard the copy with a mutex.
  */
 void set_lom_ip(const uint8_t *addr, uint8_t len)
 {
-    unsigned int key;
-
     if (len < LOM_IP_ADDR_LEN) {
         LOG_WRN("%s: short LOM IP length %u", __func__, len);
         return;
     }
 
-    key = irq_lock();
+    k_mutex_lock(&lom_ip_mutex, K_FOREVER);
     memcpy(g_lom_ip, addr, LOM_IP_ADDR_LEN);
-    irq_unlock(key);
+    k_mutex_unlock(&lom_ip_mutex);
 }
 
 /* Copy the 4 IPv4 octets to out[]; all-0xFF if the LOM has not reported one. */
 void get_lom_ip_addr(uint8_t *out)
 {
-    unsigned int key;
-
-    key = irq_lock();
+    k_mutex_lock(&lom_ip_mutex, K_FOREVER);
     memcpy(out, g_lom_ip, LOM_IP_ADDR_LEN);
-    irq_unlock(key);
+    k_mutex_unlock(&lom_ip_mutex);
 }

--- a/boards/silicom/adl_n_mec172x.h
+++ b/boards/silicom/adl_n_mec172x.h
@@ -173,4 +173,15 @@ uint8_t get_bom_id (void);
 uint8_t get_board_id (void);
 struct sbl_version *get_sbl_version(void);
 
+/**
+    LOM IPv4 address, reported to the host on request.
+    Stored in network byte order (octet[0] = most significant).
+    Populated by the LOM management transport; defaults to the all-0xFF
+    sentinel (255.255.255.255) until the LOM reports an address.
+**/
+#define LOM_IP_ADDR_LEN 4
+
+void set_lom_ip (const uint8_t *addr, uint8_t len);
+void get_lom_ip_addr (uint8_t *out);
+
 #endif /* __AZBEACH_MEC172X_H__ */

--- a/boards/silicom/adl_n_mec172x.h
+++ b/boards/silicom/adl_n_mec172x.h
@@ -174,14 +174,33 @@ uint8_t get_board_id (void);
 struct sbl_version *get_sbl_version(void);
 
 /**
-    LOM IPv4 address, reported to the host on request.
-    Stored in network byte order (octet[0] = most significant).
-    Populated by the LOM management transport; defaults to the all-0xFF
-    sentinel (255.255.255.255) until the LOM reports an address.
-**/
-#define LOM_IP_ADDR_LEN 4
+    LOM IP address (IPv4 or IPv6), reported to the host on request.
+    The address octets are stored in network byte order (octet[0] = most
+    significant). Populated by the (separately handled) LOM management
+    transport; defaults to the "not reported" sentinel until the LOM
+    reports an address.
 
-void set_lom_ip (const uint8_t *addr, uint8_t len);
-void get_lom_ip_addr (uint8_t *out);
+    The address is reported to the host as a self-describing, variable
+    length response:
+
+        byte 0   : family  - LOM_IP_FAMILY_V4 / _V6 / _NONE
+        byte 1   : prefix  - subnet mask as a CIDR bit count
+                             (0-32 for IPv4, 0-128 for IPv6)
+        byte 2.. : address - octets in network order, LOM_IPV4_ADDR_LEN
+                             (4) or LOM_IPV6_ADDR_LEN (16) bytes; absent
+                             when family is LOM_IP_FAMILY_NONE
+**/
+#define LOM_IP_FAMILY_NONE 0xFF
+#define LOM_IP_FAMILY_V4   0x04
+#define LOM_IP_FAMILY_V6   0x06
+
+#define LOM_IPV4_ADDR_LEN  4
+#define LOM_IPV6_ADDR_LEN  16
+
+/* Largest response: family(1) + prefix(1) + IPv6 address(16). */
+#define LOM_IP_RESP_MAX    (2 + LOM_IPV6_ADDR_LEN)
+
+void set_lom_ip (uint8_t family, uint8_t prefix, const uint8_t *addr, uint8_t len);
+uint8_t get_lom_ip_resp (uint8_t *out);
 
 #endif /* __AZBEACH_MEC172X_H__ */


### PR DESCRIPTION
Adds a host->EC SMC command (`SMCHOST_GET_LOM_IP`, 0x4E) that returns the LOM IP address — IPv4 or IPv6, with its subnet mask — to the host over eSPI/ACPI EC.

### Response format (self-describing, variable length)

| Byte | Field | Meaning |
|---|---|---|
| 0 | `family` | `0x04` IPv4 · `0x06` IPv6 · `0xFF` not reported |
| 1 | `prefix` | subnet mask as a CIDR bit count (0–32 IPv4, 0–128 IPv6) — e.g. `/24` = `0x18` |
| 2..N | `address` | octets in network order; 4 bytes (IPv4) or 16 bytes (IPv6); absent when family is `0xFF` |

Total: **6 bytes** (IPv4), **18 bytes** (IPv6), **2 bytes** (not reported). The host reads byte 0 to learn the family and how many address octets follow.

### Storage / accessors

The address is held in a board-level global (`g_lom_ip`, a `{family, prefix, addr[16]}` struct) mirroring the existing `sys_ids` accessor pattern. It defaults to `family == 0xFF` (not reported) until the LOM management transport populates it via `set_lom_ip(family, prefix, addr, len)`, which validates that `len` matches the family. The reader `get_lom_ip_resp()` builds the framed reply and returns its length. Access is mutex-guarded since the writer (lom_mgmt thread) and reader (smchost thread) run in different thread contexts.

Address octets are kept as a `uint8_t[]` in network order end-to-end, so the representation is endianness-neutral.

`SMCHOST_MAX_BUF_SIZE` is bumped 10 → 20 so the 18-byte IPv6 reply fits `host_res[]`.

The LOM<->EC transport that calls `set_lom_ip()` is handled separately and must carry the family + prefix + address.
